### PR TITLE
Infinite loop in Resque worker using new Resque versions

### DIFF
--- a/src/main/ruby/resque/jruby_worker.rb
+++ b/src/main/ruby/resque/jruby_worker.rb
@@ -5,7 +5,7 @@ module Resque
   # Thread-safe worker usable with JRuby, adapts most of the methods designed
   # to be used in a process per worker env to behave safely in concurrent env.
   class JRubyWorker < Worker
-    
+
     begin
       require 'jruby'
       require 'java'
@@ -14,61 +14,62 @@ module Resque
       warn "loading #{self.name} on non-jruby"
       JRUBY = false
     end
-    
+
     def initialize(*queues)
       super
       @cant_fork = true
     end
-    
+
     # reserve accepts an interval argument (on master)
-    RESERVE_ARG = instance_method(:reserve).arity != 0 # :nodoc
+    RESERVE_ACCEPTS_INTERVAL = instance_method(:reserve).arity != 0 # :nodoc
     # unregister_worker(exception = nil) changed since version 1.20.0
     UNREGISTER_WORKER_ARG = instance_method(:unregister_worker).arity != 0 # :nodoc
-    
+
     # @see Resque::Worker#work
     def work(interval = 5.0, &block)
       interval = Float(interval)
       procline "Starting" # do not change $0
       startup
-      
+
       loop do
         break if shutdown?
-        
+
         if paused?
           procline "Paused"
           pause while paused? # keep sleeping while paused
         end
-        
-        if job = RESERVE_ARG ? reserve(interval) : reserve
+
+        #noinspection RubyArgCount
+        if (job = (RESERVE_ACCEPTS_INTERVAL ? reserve(interval) : reserve))
           log "got: #{job.inspect}"
-          
+
           job.worker = self
           run_hook :before_fork, job
           working_on job
 
           procline "Processing #{job.queue} since #{Time.now.to_i}"
-          
+
           perform(job, &block)
-          
+
           done_working
         else
           break if interval.zero?
-          if RESERVE_ARG
-            log! "Sleeping for #{interval} seconds"
-            procline paused? ? "Paused" : "Waiting for #{@queues.join(',')}"
-            sleep interval            
-          else
+          if RESERVE_ACCEPTS_INTERVAL
             log! "Timed out after #{interval} seconds"
             procline paused? ? "Paused" : "Waiting for #{@queues.join(',')}"
+          else
+            log! "Sleeping for #{interval} seconds"
+            procline paused? ? "Paused" : "Waiting for #{@queues.join(',')}"
+            sleep interval
           end
         end
       end
-      
+
       unregister_worker
     rescue Exception => exception
       unregister_worker(exception)
     end
-    
+
     # No forking with JRuby !
     # @see Resque::Worker#fork
     def fork # :nodoc
@@ -80,7 +81,7 @@ module Resque
     def enable_gc_optimizations # :nodoc
       nil # we're definitely not REE
     end
-    
+
     # @see Resque::Worker#startup
     def startup
       _term_child = @term_child
@@ -94,18 +95,18 @@ module Resque
     end
 
     PAUSE_SLEEP = 0.1
-    
+
     # @see Resque::Worker#pause
     def pause
       sleep(PAUSE_SLEEP) # trap('CONT') makes no sense here
     end
-    
+
     # @see Resque::Worker#pause_processing
     def pause_processing
       log "pausing job processing"
       @paused = true
     end
-    
+
     # Registers the various signal handlers a worker responds to.
     # @see Resque::Worker#register_signal_handlers
     def register_signal_handlers
@@ -119,7 +120,7 @@ module Resque
       log! "unregister_signal_handlers does nothing"
       nil
     end
-    
+
     # Called from #shutdown!
     # @see Resque::Worker#kill_child
     def kill_child
@@ -133,28 +134,28 @@ module Resque
       log! "new_kill_child has no effect with #{self.class.name}"
       nil
     end
-    
+
     # @see Resque::Worker#inspect
     def inspect
       "#<JRubyWorker #{to_s}>"
     end
-    
+
     # @see Resque::Worker#to_s
     def to_s
       @to_s ||= "#{hostname}:#{pid}[#{thread_id}]:#{@queues.join(',')}".freeze
     end
     alias_method :id, :to_s
-    
+
     # @see Resque::Worker#hostname
     def hostname
       JRUBY ? java.net.InetAddress.getLocalHost.getHostName : super
     end
-    
+
     # @see #worker_thread_ids
     def thread_id
       JRUBY ? java.lang.Thread.currentThread.getName : nil
     end
-    
+
     # similar to the original pruning but accounts for thread-based workers
     # @see Resque::Worker#prune_dead_workers
     def prune_dead_workers
@@ -176,7 +177,7 @@ module Resque
     end
 
     WORKER_THREAD_ID = 'worker'.freeze
-    
+
     # returns worker thread names that supposely belong to the current application
     def worker_thread_ids
       thread_group = java.lang.Thread.currentThread.getThreadGroup
@@ -190,13 +191,13 @@ module Resque
         thread && thread.getName.index(WORKER_THREAD_ID) ? thread.getName : nil
       end.compact
     end
-    
+
     # Similar to Resque::Worker#worker_pids but without the worker.pid files.
     # Since this is only used to #prune_dead_workers it's fine to return PIDs
     # that have nothing to do with resque, it's only important that those PIDs
     # contain processed that are currently live on the system and perform work.
-    # 
-    # Thus the naive implementation to return all PIDs running within the OS 
+    #
+    # Thus the naive implementation to return all PIDs running within the OS
     # (under current user) is acceptable.
     def system_pids
       pids = `ps -e -o pid`.split("\n")
@@ -207,7 +208,7 @@ module Resque
     if RbConfig::CONFIG['host_os'] =~ /mswin|mingw/i
       require 'csv'
       def system_pids
-        pids_csv = `tasklist.exe /FO CSV /NH` # /FI "PID gt 1000" 
+        pids_csv = `tasklist.exe /FO CSV /NH` # /FI "PID gt 1000"
         # sample output :
         # "System Idle Process","0","Console","0","16 kB"
         # "System","4","Console","0","228 kB"
@@ -219,14 +220,14 @@ module Resque
         pids
       end
     end
-    
+
     # @see Resque::Worker#register_worker
     def register_worker
       outcome = super
       system_register_worker if JRUBY
       outcome
     end
-    
+
     # @see Resque::Worker#unregister_worker
     def unregister_worker(exception = nil)
       system_unregister_worker if JRUBY
@@ -236,7 +237,7 @@ module Resque
         super(); raise exception
       end
     end
-    
+
     # @see Resque::Worker#procline
     def procline(string = nil)
       # do not change $0 as this method otherwise would ...
@@ -246,9 +247,9 @@ module Resque
         log! @procline = "resque-#{Resque::Version}: #{string}"
       end
     end
-    
+
     if ( instance_method(:log) rescue nil ) && ! defined? Resque.logger
-      
+
       # Log a message to STDOUT if we are verbose or very_verbose.
       # @see Resque::Worker#log
       def log(message)
@@ -260,7 +261,7 @@ module Resque
           logger.info "*** #{message}"
         end
       end
-      
+
       def verbose=(value)
         if value && ! very_verbose
           logger.level = Logger::INFO
@@ -280,16 +281,16 @@ module Resque
         end
         @very_verbose = value
       end
-      
+
     else # #verbose, #very_verbose, #log, #log! removed on 2.0 [master]
-      
+
       def log(message); logger.info(message); end
       def log!(message); logger.debug(message); end
-      
+
     end
-    
+
     def logger
-      @logger ||= begin 
+      @logger ||= begin
         # [master] `Resque.logger = Logger.new(STDOUT)`
         logger = Resque.logger if defined? Resque.logger
         unless logger
@@ -305,15 +306,15 @@ module Resque
         logger
       end
     end
-    
-    # We route log output through a logger 
+
+    # We route log output through a logger
     # (instead of printing directly to stdout).
     def logger=(logger)
       @logger = logger
     end
-    
+
     private
-    
+
     # so that we can later identify a "live" worker thread
     def update_native_thread_name
       thread = JRuby.reference(Thread.current)
@@ -331,9 +332,9 @@ module Resque
         set_thread_name.call("#{name} (#{WORKER_THREAD_ID}", ')')
       end
     end
-    
+
     WORKERS_KEY = 'resque.workers'.freeze
-    
+
     # register a worked id globally (for this application)
     def system_register_worker # :nodoc
       self.class.with_global_lock do
@@ -350,7 +351,7 @@ module Resque
         self.class.store_global_property(WORKERS_KEY, workers.join(','))
       end
     end
-    
+
     # returns all registered worker ids
     def self.system_registered_workers # :nodoc
       workers = fetch_global_property(WORKERS_KEY)
@@ -358,7 +359,7 @@ module Resque
     end
 
     # low-level API probably worth moving out of here :
-    
+
     if defined?($serlet_context) && $serlet_context
 
       def self.fetch_global_property(key) # :nodoc
@@ -380,9 +381,9 @@ module Resque
       def self.with_global_lock(&block) # :nodoc
         $serlet_context.synchronized(&block)
       end
-      
+
     else # no $servlet_context assume 1 app within server/JVM (e.g. mizuno)
-      
+
       def self.fetch_global_property(key) # :nodoc
         with_global_lock do
           return java.lang.System.getProperty(key)
@@ -402,18 +403,18 @@ module Resque
       def self.with_global_lock(&block) # :nodoc
         java.lang.System.java_class.synchronized(&block)
       end
-      
+
     end
-    
+
     def self.split_id(worker_id, split_thread = true)
       # thread name might contain ':' thus split it first :
       id = worker_id.split(/\[(.*?)\]/); thread = id.delete_at(1)
       host, pid, queues = id.join.split(':')
       split_thread ? [ host, pid, thread, queues ] : [ host, pid ,queues ]
     end
-    
+
   end
-  
+
   Worker.class_eval do
     # Returns a single worker object. Accepts a string id.
     def self.find(worker_id)


### PR DESCRIPTION
Changed `RESERVE_ARG` variable to `RESERVE_ACCEPTS_INTERVAL` to make the intent of the code clearer and moved the `sleep(interval)` to the branch which isn't handled by the `reserve(interval)` call.

Tested on Mac OS X with Trinidad 1.4.4, JRuby 1.7.2, JDK 1.7.0_u10 with the worker in VVERBOSE mode. The log shows the worker sleeping for the configured interval (10 seconds) and the CPU usage is normal.
