### PR TITLE
Remove ant

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ build.xml
 catalog.xml
 Gemfile.lock
 src/test/resources/db/delayed.db
+target

--- a/Gemfile
+++ b/Gemfile
@@ -3,11 +3,13 @@ source "https://rubygems.org"
 gem 'ruby-maven'
 gem 'jruby-rack'
 
-group :test do
+group :development do
   gem 'rake'
-  gem 'test-unit', '~> 2.5.3'
-  gem 'test-unit-context'
-  gem 'mocha'
+end
+
+group :test do
+  gem 'test-unit'
+  gem 'mocha', require: 'mocha/test_unit'
 end
 
 group :delayed_job do
@@ -25,8 +27,7 @@ group :delayed_job do
       end
     end
   else
-    gem 'delayed_job'
-    gem 'delayed_job_active_record', :require => nil
+    gem 'delayed_job_active_record'
     gem 'delayed_cron_job', :require => nil
   end
   if ENV['activerecord']
@@ -34,7 +35,7 @@ group :delayed_job do
   else
     gem 'activerecord', :require => nil # for tests
   end
-  gem 'activerecord-jdbcsqlite3-adapter', '~> 1.3.20', :require => nil, :platform => :jruby
+  gem 'activerecord-jdbcsqlite3-adapter', '~> 61.3'
 end
 
 group :resque do

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,6 @@
 source "https://rubygems.org"
 
+gem 'ruby-maven'
 gem 'jruby-rack'
 
 group :test do

--- a/README.md
+++ b/README.md
@@ -265,20 +265,26 @@ end
 
 ## Build
 
-[JRuby](http://jruby.org) 1.6.8+ is required to build the project.
+[JRuby](http://jruby.org) 9.4.8.0+ is required to build the project.
 
-The build is performed by [rake](http://rake.rubyforge.org) which should be part
-of your JRuby installation, if you're experiencing conflicts with another Ruby and
-it's `rake` executable use `jruby -S rake` instead.
-Besides you will need [ant](http://ant.apache.org/) installed for the Java part.
+Install gems :
+
+    bundle install
 
 Build the *jruby-rack-worker_[VERSION].jar* using :
 
-    rake jar
+    bundle exec rake jar
 
 Build the gem (includes the .jar packaged) :
 
-    rake gem
+    bundle exec rake gem
+
+
+## Testing
+
+Run tests with:
+
+    bundle exec rake
 
 
 ## Copyright

--- a/Rakefile
+++ b/Rakefile
@@ -100,34 +100,38 @@ end
 
 namespace :test do
 
-  desc "run ruby tests"
-  task :ruby do # => :'bundler:setup'
+  task 'dependencies' do
     Rake::Task['jar'].invoke unless File.exists?(out_jar_path)
+    RubyMaven.exec('dependency:copy-dependencies', '-DincludeScope=provided', '-P!jruby-dependencies')
+  end
+
+  desc "run ruby tests"
+  task :ruby do
+    Rake::Task['test:dependencies'].invoke
     _ruby_test('src/test/ruby/**/*_test.rb')
   end
 
   desc "run DJ (ruby) tests only"
-  task 'ruby:delayed' do # => :'bundler:setup'
-    Rake::Task['jar'].invoke unless File.exists?(out_jar_path)
+  task 'ruby:delayed' do
+    Rake::Task['test:dependencies'].invoke
     _ruby_test('src/test/ruby/delayed/**/*_test.rb')
   end
 
   desc "run Resque (ruby) tests only"
-  task 'ruby:resque' do # => :'bundler:setup'
-    Rake::Task['jar'].invoke unless File.exists?(out_jar_path)
+  task 'ruby:resque' do
+    Rake::Task['test:dependencies'].invoke
     _ruby_test('src/test/ruby/resque/**/*_test.rb')
   end
 
   def _ruby_test(test_files)
     test_files = ENV['TEST'] || File.join(test_files)
-    #test_opts = (ENV['TESTOPTS'] || '').split(' ')
     test_files = FileList[test_files].map { |path| path.sub('src/test/ruby/', '') }
-    ruby "-Isrc/main/ruby:src/test/ruby", "-e", "#{test_files.inspect}.each { |test| require test }"
+    ruby "-I", "src/main/ruby:src/test/ruby", "-e", "#{test_files.inspect}.each { |test| require test }"
   end
 
   desc "run java tests"
   task :java do
-    RubyMaven.exec('verify')
+    RubyMaven.exec('verify', '-Pjruby-dependencies')
   end
 end
 

--- a/pom.rb
+++ b/pom.rb
@@ -17,14 +17,23 @@ project do
     # 'polyglot.dump.readonly' => true
   )
 
-  dependencies do
-    dependency do
-      group_id 'org.jruby'
-      artifact_id 'jruby'
-      version '9.4.8.0'
-      scope 'provided'
+  profiles do
+    profile 'jruby-dependencies' do
+      activation do
+       active_by_default true
+      end
+      dependencies do
+        dependency do
+          group_id 'org.jruby'
+          artifact_id 'jruby'
+          version '9.4.8.0'
+          scope 'provided'
+        end
+      end
     end
+  end
 
+  dependencies do
     dependency do
       group_id 'javax.servlet'
       artifact_id 'servlet-api'
@@ -37,6 +46,7 @@ project do
       artifact_id 'jruby-rack'
       version '1.1.12'
       scope 'provided'
+      exclusion 'org.jruby', 'jruby-complete'
     end
 
     dependency do

--- a/pom.rb
+++ b/pom.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+load File.join(basedir, 'src/main/ruby/jruby/rack/worker/version.rb')
+
+project do
+  model_version '4.0.0'
+
+  group_id 'org.kares.jruby.rack'
+  artifact_id 'jruby-rack-worker'
+  version JRuby::Rack::Worker::VERSION
+  packaging 'jar'
+
+  properties(
+    'project.build.sourceEncoding' => 'UTF-8',
+    'project.reporting.outputEncoding' => 'UTF-8',
+    # 'polyglot.dump.pom' => 'pom.xml',
+    # 'polyglot.dump.readonly' => true
+  )
+
+  dependencies do
+    dependency do
+      group_id 'org.jruby'
+      artifact_id 'jruby'
+      version '9.4.8.0'
+      scope 'provided'
+    end
+
+    dependency do
+      group_id 'javax.servlet'
+      artifact_id 'servlet-api'
+      version '2.4'
+      scope 'provided'
+    end
+
+    dependency do
+      group_id 'org.jruby.rack'
+      artifact_id 'jruby-rack'
+      version '1.1.12'
+      scope 'provided'
+    end
+
+    dependency do
+      group_id 'junit'
+      artifact_id 'junit'
+      version '4.11'
+      scope 'test'
+    end
+
+    dependency do
+      group_id 'org.mockito'
+      artifact_id 'mockito-all'
+      version '1.9.5'
+      scope 'test'
+    end
+  end
+
+   build do
+    plugins do
+      plugin('org.apache.maven.plugins:maven-jar-plugin') do
+        configuration(
+          archive: { 
+            manifest_entries: {
+              'Built-By' => '${user.name}',
+              'Implementation-Title' => '${project.name}',
+              'Implementation-Version' => '${project.version}',
+              'Implementation-Vendor' => 'Karol Bucek',
+              'Implementation-Vendor-Id' => 'org.kares'
+            }
+          }
+        )
+      end
+    end
+  end
+end

--- a/src/test/ruby/delayed/plugin_test.rb
+++ b/src/test/ruby/delayed/plugin_test.rb
@@ -63,7 +63,7 @@ module Delayed
       end
     end if Worker.is_a?(SyncLifecycle)
 
-    context "with backend" do
+    class WithBackendTests < Test::Unit::TestCase
 
       @@plugin = nil
 

--- a/src/test/ruby/jruby/rack/worker_test.rb
+++ b/src/test/ruby/jruby/rack/worker_test.rb
@@ -20,7 +20,7 @@ module JRuby::Rack
       assert_equal File.expand_path(jar_path), JRuby::Rack::Worker::JAR_PATH
     end
     
-    context :ENV do
+    class ENVTests < Test::Unit::TestCase
       
       test "resolves key when set" do
         assert ! JRuby::Rack::Worker::ENV.key?(:foo)

--- a/src/test/ruby/resque/jruby_worker_test.rb
+++ b/src/test/ruby/resque/jruby_worker_test.rb
@@ -1,4 +1,5 @@
 require File.expand_path('test_helper', File.dirname(__FILE__) + '/..')
+Bundler.require(:resque)
 require 'resque/jruby_worker'
 
 gem_spec = Gem.loaded_specs['resque'] if defined? Gem
@@ -338,7 +339,7 @@ module Resque
         redis.connect
       end
 
-      context "with redis" do
+    class WithRedisTests < Test::Unit::TestCase
 
         test "worker exists after it's started" do
           worker = Resque::JRubyWorker.new('foo')

--- a/src/test/ruby/test_helper.rb
+++ b/src/test/ruby/test_helper.rb
@@ -1,46 +1,7 @@
-begin
-  require 'bundler'
-rescue LoadError => e
-  require('rubygems') && retry
-  raise e
+Dir['target/dependency/*.jar'].each { |jar| next if jar =~ /jruby/; $CLASSPATH << jar }
+Bundler.require(:default, :test)
+module JRuby::Rack::Worker
+  JAR_PATH = Dir.glob("out/jruby-rack-worker_*.jar").last
 end
-Bundler.setup # require(:default, :test)
-
-gem 'test-unit' # uninitialized constant Test::Unit::TestResult::TestResultFailureSupport
-require 'test/unit'
-require 'test/unit/context'
-begin; require 'mocha/setup'; rescue LoadError; require 'mocha'; end
 
 require 'jruby/rack/worker'
-
-module JRuby
-  module Rack
-    module Worker
-      
-      @@load_jar = nil
-      
-      # NOTE: we're not packed in a .gem thus override .jar loading :
-      def self.load_jar
-        unless @@load_jar
-          @@load_jar = true
-          require 'java'
-          runtime_jars.each { |jar| load jar }
-          require Dir.glob("#{base_dir}/out/jruby-rack-worker_*.jar").last
-        end
-      end
-
-      private
-      
-      def self.runtime_jars # ivy runtime jars
-        Dir.glob("#{base_dir}/lib/runtime/*.jar").reject do |jar|
-          jar =~ /jruby-complete/ || jar =~ /geronimo/
-        end
-      end
-      
-      def self.base_dir
-        File.expand_path('../../..', File.dirname(__FILE__))
-      end
-
-    end
-  end
-end


### PR DESCRIPTION
Change ant to pom.rb

I think maven is more used at the moment and I think most of us have maven proxy settings and local maven mirros better supported than ant ones.

This pull request also changes libraries to new versions. This PR does not fix travis problems but introduces now ones.